### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: | $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run lint tests
 
 .PHONY: test tests
 test: ; $(info  running unit tests...) ## Run unit tests
-	$Q go test ./...
+	$Q go test -race ./...
 
 tests: test lint ; ## Run all tests
 


### PR DESCRIPTION
This change updates the Makefile to include the '-race' flag, enabling race detection during testing.